### PR TITLE
Fix cscope databse search when using vim-fugitive

### DIFF
--- a/plugin/cscope_maps.vim
+++ b/plugin/cscope_maps.vim
@@ -111,7 +111,9 @@ function! s:Cscope_maps_find()
     let l:modifiers = ":p:h"
     let b:cscope_path = fnameescape(expand("%" . l:modifiers))
 
-    while b:cscope_path != "/"
+    " When using expand() with more ':h' modifiers than path components,
+    " paths that do not start with a '/' will be expanded to '.'.
+    while b:cscope_path != "/" && b:cscope_path != "."
         call s:Cscope_maps_debug(3, "Trying: " . b:cscope_path)
         if filereadable(b:cscope_path . "/cscope.out")
             call s:Cscope_maps_setdb(b:cscope_path)


### PR DESCRIPTION
When using 'Gdiff' or other commands inside the fugitive plugin
the buffer name is is formated like this: 'fugitvie:///path/to/file'.
When searching upwards from there, the buffer name is never '/'
but instead reduces to '.' which leads to an infinte loop while trying
to search for the cscope database.